### PR TITLE
Fix potential URI encoding mismatch

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -17,6 +17,7 @@ const client = new Client(ENDPOINT);
 // https://stackoverflow.com/a/13419367
 function parseQuery(queryString) {
     if(queryString.length == 0) {return;}
+    queryString = queryString.replace(/\+/g, '%20'); // force URI encoding to %20 instead of +
     var query = {};
     var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split(';');
     for (var i = 0; i < pairs.length; i++) {


### PR DESCRIPTION
**Issue Fixed:** Mismatched URI encoding rules may lead to incomplete URI decoding resulting in encoded symbols being left behind as garbage symbols.

**Solution:** Modify `./client/index.js:parseQuery()` to add a `string.replace()` via regex to replace encoded symbol `+` to encoded symbol `%20`.

**Explanation:** The default HTML URI encoding has an ambiguous encoding rule for ` ` (space character) due to updated encoding convention. The resulting encoded symbol for ` ` may be either `+` or `%20`. To fix this, we force the `+` case to always match the `%20` case without creating additional encoding limitations.

**Issues Resolved/Referenced:**
https://github.com/sjsucs/osh_06/issues/20
https://github.com/sjsucs/osh_06/issues/28

## **Test Case 1:**
**Method:** Externally via a JS console.
**Input:** Query ``?key+plus%20percent%2Bencplus=value+plus%20percent%2Bencplus``
```
// extract destination parameters
// https://stackoverflow.com/a/13419367
function parseQuery(queryString) {
    if(queryString.length == 0) {return;}
    queryString = queryString.replace(/\+/g, '%20'); // force URI encoding to %20 instead of '+'
    var query = {};
    var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split(';');
    for (var i = 0; i < pairs.length; i++) {
        var pair = pairs[i].split('=');
        query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
    }
    return query;
}
console.log(parseQuery("?key+plus%20percent%2Bencplus=value+plus%20percent%2Bencplus"));
```
**Expected Result:**
```
Object with 1 Key-Value pair:
    Key = 'key plus percent+encplus'
    Value = 'value plus percent+encplus'
```
**Actual Result Before Fix:**
```
Object { key+plus percent+encplus: "value+plus percent+encplus" }
           ~~~                          ~~~
```
**Actual Result After Fix:**
```
Object { key plus percent+encplus: "value plus percent+encplus" }
```
**Explanation:** The query consists of both possible encoded symbols for ` ` and the encoded symbol for `+` . We test all 3 symbols to see if they are properly decoded. Notice that the plaintext `+` can still be used due to being encoded as `%2B` and therefore unaffected by the added `string.replace()` line. All symbols are properly decoded therefore this test case is a pass.